### PR TITLE
testAPIでのレスポンスエラー修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::API
         include DeviseTokenAuth::Concerns::SetUserByToken
-      
+
         alias_method :current_user, :current_api_v1_user
+
+        before_action :set_cors_headers
+
+        private
+
+        def set_cors_headers
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+        end
 end
-      

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,11 +7,12 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "localhost:3000"
+    origins "http://localhost:5173"
 
     resource "*",
       headers: :any,
       expose: [ 'access-token', 'expiry', 'token-type', 'uid', 'client' ],
-      methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ],
+      credentials: true
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       RAILS_ENV: development
       RAILS_MAX_THREADS: 5
     ports:
-      - "5173:5173"
+      - "3001:3000"
     depends_on:
       - db
     container_name: match_api


### PR DESCRIPTION
CORSの設定、バックエンドのレスポンスヘッダーにAccess-Control-Allow-Credentials: trueが含まれていないために修正。
ApplicationControllerにbefore_actionを追加して、すべてのリクエストに対してCORSヘッダーを設定するようにしました。
set_cors_headersメソッドを追加して、Access-Control-Allow-Credentialsヘッダーをtrueに設定するようにしました。